### PR TITLE
Add GitHub Actions CD workflow #5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name:Deploy to VPS
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up SSH key
+        uses: webfactory/ssh-agent@v0.8.1
+        with:
+          ssh-private-key: ${{ secrets.VPS_SSH_KEY }}
+
+      - name: Deploy to VPS
+        run: |
+          ssh -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} << 'EOF'
+            cd ~/first_app
+            git pull origin main
+            source venv/bin/activate
+            sudo systemctl restart first_app
+          EOF


### PR DESCRIPTION
## 🚀 概要

GitHub Actionsによる自動デプロイ（CD）パイプラインを構築しました。
`main` ブランチにPushされると、GitHub ActionsからVPSにSSH接続し、Flaskアプリをデプロイします。

---

## 🛠️ 変更内容

- `.github/workflows/deploy.yml` を新規追加
- GitHub Secretsに登録したSSH情報でVPSへ接続
- `cd ~/first_app && git pull && systemctl restart` を実行

---

## ✅ 確認手順

1. このPRを `main` にマージ
2. GitHub Actionsの `🚀 Deploy to VPS` ワークフローが実行される
3. 成功すれば `curl https://takemiko.com/api/greet?name=みこと` で最新コードが反映されていることを確認

---

## 🔐 使用Secrets

- `VPS_SSH_KEY`
- `VPS_USER`
- `VPS_HOST`

---

## 🔗 関連Issue

Close #6