### PR TITLE
Fix YAML syntax error in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up SSH key
-        uses: webfactory/ssh-agent@v0.8.1
+        uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.VPS_SSH_KEY }}
 


### PR DESCRIPTION
## 🚀 概要

GitHub Actionsによる自動デプロイ（CD）機能を導入しました。
`main` ブランチにマージされた際に、GitHub ActionsからVPSへSSH接続し、Flaskアプリを自動更新します。

---

## 🔧 変更内容

- `.github/workflows/deploy.yml` を新規作成
- `webfactory/ssh-agent@v0.5.4` を使用してSSH接続を実現
- VPS内で `git pull`, `source venv/bin/activate`, `systemctl restart first_app` を自動実行

---

## 🔐 使用するSecrets

- `VPS_SSH_KEY`：GitHub Actions用のSSH秘密鍵
- `VPS_USER`：VPSのユーザー名（例：takemiko）
- `VPS_HOST`：VPSのホスト名 or IPアドレス（例：162.43.xxx.xxx）

---

## ✅ 確認方法

1. このPRを `main` にマージ
2. `Actions` タブに `🚀 Deploy to VPS` ワークフローが表示され、自動実行される
3. VPS側でアプリが再起動され、反映されていることを確認

例：

```bash
curl https://takemiko.com/api/greet?name=みこと